### PR TITLE
Tc/error report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "pandas",
   "scikit-learn",
   "joblib",
+  "regex",
   "sphinx",
   "sphinx-rtd-theme"
 ]

--- a/src/slurmise/job_data.py
+++ b/src/slurmise/job_data.py
@@ -20,7 +20,7 @@ def array_safe_eq(a, b) -> bool:
         )
     try:
         return a == b
-    except TypeError:
+    except TypeError:   # pragma: no cover
         return NotImplemented
 
 
@@ -31,7 +31,7 @@ def dc_eq(dc1, dc2) -> bool:
 
     if dc1 is dc2:
         return True
-    if dc1.__class__ is not dc2.__class__:
+    if dc1.__class__ is not dc2.__class__:   # pragma: no cover
         return NotImplemented  # better than False
     t1 = astuple(dc1)
     t2 = astuple(dc2)

--- a/src/slurmise/job_parse/file_parsers.py
+++ b/src/slurmise/job_parse/file_parsers.py
@@ -14,7 +14,7 @@ class FileParser:
     name: str = 'UNK'
     return_type: str = NUMERICAL
 
-    def parse_file(self, path: Path, gzip_file: bool=False):
+    def parse_file(self, path: Path, gzip_file: bool=False):   # pragma: no cover
         raise NotImplementedError()
 
 
@@ -35,10 +35,6 @@ class FileMD5(FileParser):
     def parse_file(self, path: Path, gzip_file: bool=False):
         md5_hash = hashlib.md5()
         md5_hash.update(path.read_bytes())
-        # with path.read_bytes() as file:
-        #     # Read the file in chunks to handle large files efficiently
-        #     for chunk in iter(lambda: file.read(4096), b""):
-        #         md5_hash.update(chunk)
         return md5_hash.hexdigest()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,8 +93,9 @@ def test_parse_job_cmd_with_ignore(basic_toml):
 
 def test_parse_job_cmd_invalid(basic_toml):
     config = SlurmiseConfiguration(basic_toml)
-    with pytest.raises(ValueError, match="Job spec monomer -T {threads:numeric} -C {complexity:category} does not match command dimer -T 1 -C simple."):
+    with pytest.raises(ValueError, match="Job spec for nupack does not match command:") as ve:
         config.parse_job_cmd("dimer -T 1 -C simple", "nupack", "1234")
+    print(f'\n{ve.value}')
 
 def test_parse_job_cmd_name_mismatch(basic_toml):
     config = SlurmiseConfiguration(basic_toml)
@@ -103,8 +104,9 @@ def test_parse_job_cmd_name_mismatch(basic_toml):
 
 def test_parse_job_cmd_invalid_numeric(basic_toml):
     config = SlurmiseConfiguration(basic_toml)
-    with pytest.raises(ValueError, match="Job spec monomer -T {threads:numeric} -C {complexity:category} does not match command monomer -T 1A -C simple."):
+    with pytest.raises(ValueError, match="Job spec for nupack does not match command:") as ve:
         config.parse_job_cmd("monomer -T 1A -C simple", "nupack", "1234")
+    print(f'\n{ve.value}')
 
 def test_awk_parsers(basic_toml):
     config = SlurmiseConfiguration(basic_toml)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -114,6 +114,25 @@ def test_raw_record(simple_toml):
 
         assert query_result == excepted_results
 
+    # test the db can print the new values
+    result = runner.invoke(
+        main,
+        [
+            "--toml",
+            simple_toml.toml,
+            "print",
+        ],
+    )
+    assert result.exit_code == 0
+
+    split_std = result.stdout.split('\n')
+    assert split_std[0] == 'test'
+    assert split_std[1].split('-')[-1] == ' a=1'
+    assert split_std[2].split('-')[-1] == ' b=2'
+    assert split_std[3].split('-')[-1] == ' 1234'
+    assert split_std[4].split('-')[-1] == ' n: () int64 3'
+    assert split_std[5].split('-')[-1] == ' q: () float64 17.4'
+
 
 def test_update_predict(nupack_toml):
     """Test the update and predict commands of slurmise.
@@ -134,7 +153,7 @@ def test_update_predict(nupack_toml):
         ],
         catch_exceptions=True,
     )
-    if result.exception:
+    if result.exception:  # pragma: no cover
         print(f"Exception: {result.exception}")
     assert result.exit_code == 0
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -28,6 +28,61 @@ def test_job_spec_token_with_no_name():
     with pytest.raises(ValueError, match="Token {numeric} has no name."):
         JobSpec('cmd -T {numeric}')
 
+def test_basic_job_spec():
+    spec = JobSpec('cmd -T {threads:numeric}')
+
+    jd = spec.parse_job_cmd(JobData(job_name='test', cmd='cmd -T 3'))
+    assert jd.numerical == {'threads': 3}
+
+def test_job_spec_failure_swap():
+    spec = JobSpec('cmd -T {threads:numeric} -S {another:category}')
+
+    with pytest.raises(ValueError, match="Job spec for test does not match command:") as ve:
+        spec.parse_job_cmd(JobData(job_name='test', cmd='cmd -S simple -T 5'))
+    print(f'\n{ve.value}')
+
+def test_job_spec_failure_typos():
+    spec = JobSpec('cmd -T {threads:numeric} -S {another:category}')
+
+    with pytest.raises(ValueError, match="Job spec for test does not match command:") as ve:
+        spec.parse_job_cmd(JobData(job_name='test', cmd='cnd -t 5 -S simple'))
+    print(f'\n{ve.value}')
+
+def test_basic_job_spec_extra_cmd_prefix():
+    spec = JobSpec('cmd -T {threads:numeric} -S {another:category}')
+
+    with pytest.raises(ValueError, match="Job spec for test does not match command:") as ve:
+        spec.parse_job_cmd(JobData(job_name='test', cmd='extra cmd -T 3 -S beep'))
+    print(f'\n{ve.value}')
+
+def test_basic_job_spec_extra_spec_prefix():
+    spec = JobSpec('extra cmd -T {threads:numeric} -S {another:category}')
+
+    with pytest.raises(ValueError, match="Job spec for test does not match command:") as ve:
+        spec.parse_job_cmd(JobData(job_name='test', cmd='cmd -T 3 -S beep'))
+    print(f'\n{ve.value}')
+
+def test_basic_job_spec_extra_spec_suffix():
+    spec = JobSpec('cmd -T {threads:numeric} -S {another:category} extra')
+
+    with pytest.raises(ValueError, match="Job spec for test does not match command:") as ve:
+        spec.parse_job_cmd(JobData(job_name='test', cmd='cmd -T 3 -S cat'))
+    print(f'\n{ve.value}')
+
+def test_basic_job_spec_extra_spec_internal():
+    spec = JobSpec('cmd -T {threads:numeric} extra -S {another:category}')
+
+    with pytest.raises(ValueError, match="Job spec for test does not match command:") as ve:
+        spec.parse_job_cmd(JobData(job_name='test', cmd='cmd -T 3 -S cat'))
+    print(f'\n{ve.value}')
+
+def test_basic_job_spec_extra_cmd_internal():
+    spec = JobSpec('cmd -T {threads:numeric} -S {another:category}')
+
+    with pytest.raises(ValueError, match="Job spec for test does not match command:") as ve:
+        spec.parse_job_cmd(JobData(job_name='test', cmd='cmd -T 3 extra -S cat'))
+    print(f'\n{ve.value}')
+
 def test_job_spec_with_builtin_parsers_basename(tmp_path):
     '''
         [slurmise.job.builtin_files]


### PR DESCRIPTION
Added richer markup for errors caused by command and job specification mismatches.

Tested a few basic conditions, I figure we can add more as we get reports of strange behavior.

To see the markup in the tests, run `hatch test` with `-s` to skip stdout capture.  Here are some examples:
```
Job spec for nupack does not match command:
monomer -T {threads⇒1} -C {complexity⇒simple}
╳╳╳╳       │         │    │                 │
di  mer -T └───┤1├───┘ -C └─────┤simple├────┘

Job spec for nupack does not match command:
monomer -T {threads⇒1A} -C {complexity⇒simple}
           │     ⚠    │    │                 │
monomer -T └───┤1A├───┘ -C └─────┤simple├────┘

tests/test_parsing.py ....
Job spec for test does not match command:
cmd -T {threads⇒} -S {another⇒simple -T 5}
   ∧∧∧∧│    ⚠   │    │                   │
cmd    └───┤├───┘ -S └───┤simple -T 5├───┘

Job spec for test does not match command:
cmd -T {threads⇒5} -S {another⇒simple}
 ╳   ╳ │         │    │              │
cnd -t └───┤5├───┘ -S └───┤simple├───┘
```