### PR TITLE
feat: add parse command

### DIFF
--- a/src/slurmise/__main__.py
+++ b/src/slurmise/__main__.py
@@ -35,8 +35,19 @@ def record(ctx, cmd, job_name, slurm_id, step_id):
     """Command to record a job.
     For example: `slurmise record "-o 2 -i 3 -m fast"`
     """
-
     ctx.obj["slurmise"].record(cmd, job_name, slurm_id, step_id)
+
+
+@main.command()
+@click.argument("cmd", nargs=1)
+@click.option("--job-name", type=str, help="Name of the job")
+@click.pass_context
+def parse(ctx, cmd, job_name):
+    """Command to record a job.
+    For example: `slurmise record "-o 2 -i 3 -m fast"`
+    """
+    parsed_output = ctx.obj["slurmise"].dry_parse(cmd, job_name)
+    click.echo(parsed_output)
 
 
 @main.command()

--- a/src/slurmise/api.py
+++ b/src/slurmise/api.py
@@ -38,6 +38,17 @@ class Slurmise:
         ) as database:
             database.record(parsed_jd)
 
+    def dry_parse(
+        self,
+        cmd: str,
+        job_name: str | None = None,
+    ):
+        parsed_output = self.configuration.dry_parse(
+            cmd=cmd,
+            job_name=job_name,
+        )
+        return parsed_output
+
     def raw_record(self, job_data):
         with job_database.JobDatabase.get_database(
             self.configuration.db_filename

--- a/src/slurmise/config.py
+++ b/src/slurmise/config.py
@@ -61,6 +61,30 @@ class SlurmiseConfiguration:
             step_id: str | None = None
             ) -> job_data.JobData:
         """Parse a job data dataset into a JobData object."""
+
+        jd = self._fill_job_name(cmd, job_name, slurm_id, step_id)
+        job_spec = self.jobs[jd.job_name]["job_spec_obj"]
+
+        return job_spec.parse_job_cmd(jd)
+
+    def dry_parse(
+            self,
+            cmd: str,
+            job_name: str | None = None,
+        ):
+
+        jd = self._fill_job_name(cmd, job_name)
+        job_spec = self.jobs[jd.job_name]["job_spec_obj"]
+        return job_spec.align_and_indicate_differences(jd.cmd, try_exact_match=True)
+
+    def _fill_job_name(
+            self,
+            cmd: str,
+            job_name: str | None = None,
+            slurm_id: str | None = None,
+            step_id: str | None = None,
+        ) -> job_data.JobData:
+        """From the user supplied input, create a job data object."""
         if job_name is None:  # try to infer
             for name, prefix in self.job_prefixes.items():
                 if cmd.startswith(prefix):
@@ -87,14 +111,12 @@ class SlurmiseConfiguration:
 
         if step_id is not None:
             slurm_id = '.'.join([str(slurm_id), str(step_id)])
-        jd = job_data.JobData(
+        return job_data.JobData(
             job_name=job_name,
             slurm_id=slurm_id,
             cmd=cmd
         )
 
-        job_spec = self.jobs[job_name]["job_spec_obj"]
-        return job_spec.parse_job_cmd(jd)
 
     def add_defaults(self, job_data: job_data.JobData) -> job_data.JobData:
         """Add default values to a job data object."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -263,3 +263,19 @@ def test_predict_nomodel(nupackdefaults_toml):
     assert "Predicted memory" == predicted_memory[0]
     assert float(predicted_memory[1]) == 3000
     assert "Warnings:" in result.stderr
+
+def test_parse(simple_toml):
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--toml",
+            simple_toml.toml,
+            "parse",
+            "nupack monomer -T 2 -C simple",
+        ],
+    )
+    assert result.exit_code == 0
+
+    assert result.stdout.startswith("Able to parse")

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -90,6 +90,19 @@ def test_basic_job_spec_with_ignore():
         spec.parse_job_cmd(JobData(job_name='test', cmd='cmd ignore me please -T 3 and this too -s cat'))
     print(f'\n{ve.value}')
 
+def test_try_exact_passes():
+    spec = JobSpec('cmd -T {threads:numeric} -S {another:category}')
+    result = spec.align_and_indicate_differences('cmd -T 3 -S cat', try_exact_match=True)
+    print(f'\n{result}')
+    assert result.startswith('Able to parse')
+
+def test_try_exact_fails():
+    spec = JobSpec('cmd -T {threads:numeric} -S {another:category}')
+    result = spec.align_and_indicate_differences('FAILURE -T 3 -S cat', try_exact_match=True)
+    print(f'\n{result}')
+    assert result.startswith('Failed to parse')
+
+
 @pytest.mark.skip
 def test_long_job_spec():
     spec = JobSpec(


### PR DESCRIPTION
Added parse command to perform a dry run of parsing.

Invoked with `slurmise --toml TOML parse "command"`.  When passing results look like
```
Able to parse
cmd -T {threads⇒3} -S {another⇒cat}
       │         │    │           │
cmd -T └───┤3├───┘ -S └───┤cat├───┘
```
While failures are similar to the current error reporting, but also include the message "Failed to parse".