### PR TITLE
feat: add from_dict contructors for job data objects

### DIFF
--- a/src/slurmise/api.py
+++ b/src/slurmise/api.py
@@ -58,6 +58,7 @@ class Slurmise:
         else:
             # If no step_id is provided, use the slurm_id as is
             slurm_id, step_name = job_data.slurm_id, None
+
         metadata_json = slurm.parse_slurm_job_metadata(
             slurm_id=slurm_id, step_name=step_name
         )
@@ -122,3 +123,14 @@ class Slurmise:
         ) as database:
             for query_jd, jobs in database.iterate_database():
                 self._update_model(query_jd, jobs)
+
+    def job_data_from_dict(
+        self,
+        variables: dict,
+        job_name: str,
+        slurm_id: str | None = None,
+        step_id: str | None = None,
+        ):
+        return self.configuration.parse_job_from_dict(
+            variables, job_name, slurm_id, step_id,
+        )

--- a/src/slurmise/config.py
+++ b/src/slurmise/config.py
@@ -67,6 +67,20 @@ class SlurmiseConfiguration:
 
         return job_spec.parse_job_cmd(jd)
 
+    def parse_job_from_dict(
+        self,
+        variables: dict,
+        job_name: str,
+        slurm_id: str | None = None,
+        step_id: str | None = None,
+        ) -> job_data.JobData:
+        """Parse a job data dataset into a JobData object."""
+
+        jd = self._fill_job_name("", job_name, slurm_id, step_id)
+        job_spec = self.jobs[jd.job_name]["job_spec_obj"]
+
+        return job_spec.parse_job_from_dict(variables, jd)
+
     def dry_parse(
             self,
             cmd: str,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -55,3 +55,12 @@ def test_multiple_slurmise_instances(simple_toml):
         while not error_queue.empty():
             print(error_queue.get())
         pytest.fail("Child prcess had error")
+
+def test_job_data_from_dict(simple_toml):
+    slurmise = Slurmise(simple_toml.toml)
+    result = slurmise.job_data_from_dict(
+        {'threads': 3, 'complexity': 'simple'},
+        'nupack',
+    )
+    assert result.categorical == {'complexity': 'simple'}
+    assert result.numerical == {'threads': 3}

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -34,6 +34,30 @@ def test_basic_job_spec():
     jd = spec.parse_job_cmd(JobData(job_name='test', cmd='cmd -T 3'))
     assert jd.numerical == {'threads': 3}
 
+def test_basic_job_spec_from_dict():
+    spec = JobSpec('cmd -T {threads:numeric}')
+
+    jd = spec.parse_job_from_dict({'threads': 3}, JobData(job_name='test'))
+    assert jd.numerical == {'threads': 3}
+
+def test_basic_job_spec_from_dict_extra_in_dict():
+    spec = JobSpec('cmd -T {threads:numeric}')
+
+    with pytest.raises(ValueError, match="Dict contained extra variable: 'extra'") as ve:
+        spec.parse_job_from_dict(
+            {'threads': 3, 'extra': 'something'},
+            JobData(job_name='test'),
+        )
+
+def test_basic_job_spec_from_dict_missing_in_dict():
+    spec = JobSpec('cmd -T {threads:numeric}')
+
+    with pytest.raises(ValueError, match="Dict missing variable: 'threads'") as ve:
+        spec.parse_job_from_dict(
+            {},
+            JobData(job_name='test'),
+        )
+
 def test_job_spec_failure_swap():
     spec = JobSpec('cmd -T {threads:numeric} -S {another:category}')
 
@@ -153,6 +177,15 @@ def test_job_spec_with_builtin_parsers_basename(tmp_path):
         JobData(
             job_name='test',
             cmd=command,
+            ))
+    assert jd.job_name == 'test'
+    assert jd.numerical == {}
+    assert jd.categorical == {'input1_file_basename': 'input.txt'}
+
+    jd = spec.parse_job_from_dict(
+        {'input1': input_file},
+        JobData(
+            job_name='test',
             ))
     assert jd.job_name == 'test'
     assert jd.numerical == {}


### PR DESCRIPTION
First attempt to make the api a little easier (?) for raw record and predict.

Instead of constructing a job data object, can call `slurmise.job_data_from_dict` which returns a job data object for use in predict or record.

```
def test_job_data_from_dict(simple_toml):
    slurmise = Slurmise(simple_toml.toml)
    result = slurmise.job_data_from_dict(
        {'threads': 3, 'complexity': 'simple'},
        'nupack',
    )
    assert result.categorical == {'complexity': 'simple'}
    assert result.numerical == {'threads': 3}
```

I was able to take most of the job parsing code and replace match groups with a call to the match's group_dict.  Then I reused most of that helper function.  Note that the job name is then required.  Let me know if you think that could be improved.