### PR TITLE
fix: better errors with missing file parsers

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,12 +16,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-  
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-  
+
       - name: Cache Python dependencies
         uses: actions/cache@v3
         with:

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ awk_script = "/path/to/awk/file.awk"
 script_is_file = True
 
 # contents of file.awk
-# /^>/ {if (seq) print seq; seq=0} 
-# /^>/ {next} 
-# {seq = seq + length($0)} 
+# /^>/ {if (seq) print seq; seq=0}
+# /^>/ {next}
+# {seq = seq + length($0)}
 # END {if (seq) print seq}
 ```
 The first extracts the token after `epochs: ` as a number and could be used for

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -112,6 +112,23 @@ def basic_toml_inconsistent_spec_type(tmpdir):
 
 
 @pytest.fixture
+def basic_toml_file_no_parser(tmpdir):
+    d = tmpdir.mkdir("slurmise_dir")
+    f = d.join("basic.toml")
+
+    toml_str = """
+    [slurmise]
+    base_dir = "slurmise_dir"
+
+    [slurmise.job.nupack]
+    job_spec = "monomer -T {threads:numeric} -C {complexity:file}"
+    """
+
+    f.write(toml_str)
+    return f
+
+
+@pytest.fixture
 def basic_toml_inconsistent_spec_name(tmpdir):
     d = tmpdir.mkdir("slurmise_dir")
     f = d.join("basic.toml")
@@ -168,6 +185,11 @@ def test_init_SlurmiseConfiguration_wrong_name(basic_toml_inconsistent_spec_name
 def test_init_SlurmiseConfiguration_wrong_spec_type(basic_toml_inconsistent_spec_type):
     with pytest.raises(ValueError, match="Unable to validate variables for nupack"):
         SlurmiseConfiguration(basic_toml_inconsistent_spec_type)
+
+
+def test_init_SlurmiseConfiguration_missing_file(basic_toml_file_no_parser):
+    with pytest.raises(ValueError, match="File 'complexity' has no assigned file parser"):
+        SlurmiseConfiguration(basic_toml_file_no_parser)
 
 
 def test_init_SlurmiseConfiguration_unknown_variable_type(basic_toml_variables_unknown_type):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -175,6 +175,41 @@ def test_long_job_spec():
     print(f"\n{ve.value}")
 
 
+def test_job_spec_with_no_file_parser(tmp_path):
+    """
+    [slurmise.job.builtin_files]
+    job_spec = "--input1 {input1:file}"
+    """
+    available_parsers = {
+        "file_basename": file_parsers.FileBasename(),
+    }
+
+    with pytest.raises(ValueError, match="File 'input1' has no assigned file parser"):
+        JobSpec(
+            "--input1 {input1:file}",
+            file_parsers={},
+            available_parsers=available_parsers,
+        )
+
+
+def test_job_spec_with_parser_not_available(tmp_path):
+    """
+    [slurmise.job.builtin_files]
+    job_spec = "--input1 {input1:file}"
+    file_parsers.input1 = "file_basename"
+    """
+    available_parsers = {
+        "file_basename": file_parsers.FileBasename(),
+    }
+
+    with pytest.raises(ValueError, match=("The parser 'file_bassname' is not available for file 'input1'")):
+        JobSpec(
+            "--input1 {input1:file}",
+            file_parsers={"input1": "file_bassname"},
+            available_parsers=available_parsers,
+        )
+
+
 def test_job_spec_with_builtin_parsers_basename(tmp_path):
     """
     [slurmise.job.builtin_files]


### PR DESCRIPTION
Rob ran into an issue where a file was specified in his toml without a corresponding file parser.  Something like 
```
    [slurmise]
    base_dir = "slurmise_dir"

    [slurmise.job.nupack]
    job_spec = "monomer -T {threads:numeric} -C {complexity:file}"
```
Where complexity is a file but no parser is given.

Previously this would result in a key error during parsing of a command.  This PR updates the behavior to give informative errors on initialization of the file parser.