### PR TITLE
chore: Only import slurmise.fit when necessary

### DIFF
--- a/src/slurmise/config.py
+++ b/src/slurmise/config.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from pathlib import Path
 
 from slurmise import job_data
-from slurmise.fit import model_factory
 from slurmise.job_parse import file_parsers
 from slurmise.job_parse.job_specification import JobSpec
 
@@ -171,4 +170,7 @@ class SlurmiseConfiguration:
         """Returns the model class a job is using."""
         model_config = self.jobs[job_name].get("model", {})
         model_name = model_config.get("model", "poly")
+
+        from slurmise.fit import model_factory
+
         return model_factory(model_name)


### PR DESCRIPTION
- Noticing that `slurmise --help` would take a second or two, which isn't bad but felt a little sluggish

- I've tested defering slurmise.fit import to only occur when it's needed and the `slurmise --help` was ~0.3 seconds instead of 1.5 seconds. sklearn is a "heavy" import

- Henry's been talking about lazy imports but I think those are only available in 3.15 so I just moved the import into the only config function that needs it