### PR TITLE
Allow `slurmise print` without a toml config

### DIFF
--- a/src/slurmise/__main__.py
+++ b/src/slurmise/__main__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from pathlib import Path
 
 import click
 
@@ -48,11 +49,14 @@ def _report_prediction(query_jd: job_data.JobData, query_warns: list[str]) -> No
 )
 @click.pass_context
 def main(ctx, toml):
+    ctx.ensure_object(dict)
+    # `print` can operate on a bare .h5 path and does not require a toml config.
     if toml is None:
+        if ctx.invoked_subcommand == "print":
+            return
         click.echo("Slurmise requires a toml file", err=True)
         click.echo("See readme for more information", err=True)
         sys.exit(1)
-    ctx.ensure_object(dict)
     ctx.obj["slurmise"] = Slurmise(toml)
 
 
@@ -107,9 +111,30 @@ def raw_record(ctx, job_name, slurm_id, step_id, numerics, categories, cmd):
 
 
 @main.command()
+@click.argument("h5_path", type=click.Path(exists=True), required=False)
 @click.pass_context
-def print(ctx):  # noqa: A001
-    ctx.obj["slurmise"].print()
+def print(ctx, h5_path):  # noqa: A001
+    """Print the contents of a slurmise database.
+
+    The database is resolved in this order: the H5_PATH argument if given,
+    otherwise the database configured by --toml, otherwise ./slurmise.h5 in
+    the current directory.
+    """
+    if h5_path is None and "slurmise" in ctx.obj:
+        # Derive the database path from the provided toml configuration.
+        ctx.obj["slurmise"].print()
+        return
+
+    if h5_path is None:
+        h5_path = "slurmise.h5"
+        if not Path(h5_path).exists():
+            click.echo(
+                "No database found: pass an .h5 path, use --toml, or run from a directory containing slurmise.h5",
+                err=True,
+            )
+            sys.exit(1)
+
+    Slurmise.print_database(h5_path)
 
 
 @main.command()

--- a/src/slurmise/__main__.py
+++ b/src/slurmise/__main__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import sys
-from pathlib import Path
 
 import click
 
@@ -117,22 +116,23 @@ def print(ctx, h5_path):  # noqa: A001
     """Print the contents of a slurmise database.
 
     The database is resolved in this order: the H5_PATH argument if given,
-    otherwise the database configured by --toml, otherwise ./slurmise.h5 in
-    the current directory.
+    otherwise the database configured by --toml
     """
-    if h5_path is None and "slurmise" in ctx.obj:
+    if h5_path is None and "slurmise" not in ctx.obj:
+        click.echo(
+            "No database found. "
+            + click.style("slurmise print", bold=True)
+            + " requires either a toml file or an h5 file path:",
+            err=True,
+        )
+        click.echo(" - slurmise --toml slurmise.toml print", err=True)
+        click.echo(" - slurmise print slurmise.h5", err=True)
+        sys.exit(1)
+
+    if "slurmise" in ctx.obj:
         # Derive the database path from the provided toml configuration.
         ctx.obj["slurmise"].print()
         return
-
-    if h5_path is None:
-        h5_path = "slurmise.h5"
-        if not Path(h5_path).exists():
-            click.echo(
-                "No database found: pass an .h5 path, use --toml, or run from a directory containing slurmise.h5",
-                err=True,
-            )
-            sys.exit(1)
 
     Slurmise.print_database(h5_path)
 

--- a/src/slurmise/api.py
+++ b/src/slurmise/api.py
@@ -57,7 +57,16 @@ class Slurmise:
             database.record(job_data)
 
     def print(self):
-        with job_database.JobDatabase.get_database(self.configuration.db_filename) as database:
+        self.print_database(self.configuration.db_filename)
+
+    @classmethod
+    def print_database(cls, h5_path):
+        """Print the contents of a slurmise HDF5 database.
+
+        This does not require a toml configuration; only the path to the
+        ``.h5`` database is needed.
+        """
+        with job_database.JobDatabase.get_database(h5_path) as database:
             database.print()
 
     def predict(self, cmd, job_name):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -147,6 +147,46 @@ def test_raw_record(simple_toml, monkeypatch):
     assert split_std[3].split("-")[-1] == " 1234"
 
 
+def _make_print_db(path):
+    with job_database.JobDatabase.get_database(str(path)) as db:
+        db.record(JobData(job_name="test_job", slurm_id="1", runtime=5, memory=100))
+
+
+def test_print_explicit_h5_path(tmp_path):
+    """print accepts a bare .h5 path with no toml configuration."""
+    h5 = tmp_path / "mydb.h5"
+    _make_print_db(h5)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["print", str(h5)])
+
+    assert result.exit_code == 0
+    assert "test_job" in result.stdout
+
+
+def test_print_defaults_to_cwd(tmp_path, monkeypatch):
+    """print falls back to ./slurmise.h5 when no path or toml is given."""
+    _make_print_db(tmp_path / "slurmise.h5")
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["print"])
+
+    assert result.exit_code == 0
+    assert "test_job" in result.stdout
+
+
+def test_print_missing_default(tmp_path, monkeypatch):
+    """print errors clearly when no database can be resolved."""
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["print"])
+
+    assert result.exit_code == 1
+    assert "No database found" in result.output
+
+
 def test_update_predict(nupack_toml):
     """Test the update and predict commands of slurmise.
     Initially, we run the update command to get the models for the nupack job.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -164,18 +164,6 @@ def test_print_explicit_h5_path(tmp_path):
     assert "test_job" in result.stdout
 
 
-def test_print_defaults_to_cwd(tmp_path, monkeypatch):
-    """print falls back to ./slurmise.h5 when no path or toml is given."""
-    _make_print_db(tmp_path / "slurmise.h5")
-    monkeypatch.chdir(tmp_path)
-
-    runner = CliRunner()
-    result = runner.invoke(main, ["print"])
-
-    assert result.exit_code == 0
-    assert "test_job" in result.stdout
-
-
 def test_print_missing_default(tmp_path, monkeypatch):
     """print errors clearly when no database can be resolved."""
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary

`slurmise print` previously required the global `--toml` option, even though it only needs to locate the `.h5` database. This PR lets `print` run with just an `.h5` path (or none at all).

The database is now resolved in this order:
1. An explicit `.h5` path argument
2. The database configured by `--toml`
3. `slurmise.h5` in the current working directory

If none can be found, it exits with a clear error.

## Usage

```bash
slurmise print path/to/db.h5        # explicit path, no toml needed
slurmise print                      # uses ./slurmise.h5
slurmise --toml cfg.toml print      # unchanged, resolves from toml
```