### PR TITLE
fix: centralize slurm job id resolution in slurm.py

### DIFF
--- a/src/slurmise/__main__.py
+++ b/src/slurmise/__main__.py
@@ -5,7 +5,7 @@ import sys
 
 import click
 
-from slurmise import job_data
+from slurmise import job_data, slurm
 from slurmise.api import Slurmise
 
 
@@ -99,7 +99,7 @@ def parse(ctx, cmd, job_name):
 @click.pass_context
 def raw_record(ctx, job_name, slurm_id, step_id, numerics, categories, cmd):
     """Record a job"""
-    slurm_id = f"{slurm_id}.{step_id}" if step_id is not None else slurm_id
+    slurm_id = slurm.resolve_job_id(slurm_id, step_id)
 
     jd = _parse_json_options(categories, numerics, job_name, cmd, slurm_id)
 

--- a/src/slurmise/api.py
+++ b/src/slurmise/api.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 import numpy as np
 
 from slurmise import job_database, slurm
@@ -27,7 +25,8 @@ class Slurmise:
         parsed_jd = self.configuration.parse_job_cmd(
             cmd=cmd,
             job_name=job_name,
-            slurm_id=f"{slurm_id}.{step_id}" if step_id is not None else slurm_id,
+            slurm_id=slurm_id,
+            step_id=step_id,
         )
         self.raw_record(parsed_jd)
 
@@ -43,18 +42,10 @@ class Slurmise:
 
     def raw_record(self, job_data, processed_data=False):
         if not processed_data:
-            if job_data.slurm_id is None:
-                job_data.slurm_id = os.environ.get("SLURM_JOB_ID")
-            if job_data.slurm_id is None:
-                raise ValueError("slurm_id was not provided and SLURM_JOB_ID environment variable is not set.")
-            if "." in job_data.slurm_id:
-                # If the slurm_id is in the format "1234.0", split it to get the step_id
-                slurm_id, step_name = job_data.slurm_id.split(".")
-            else:
-                # If no step_id is provided, use the slurm_id as is
-                slurm_id, step_name = job_data.slurm_id, None
+            job_data.slurm_id = slurm.resolve_job_id(job_data.slurm_id)
+            slurm_id, step_id = slurm.split_job_id(job_data.slurm_id)
 
-            metadata_json = slurm.parse_slurm_job_metadata(slurm_id=slurm_id, step_name=step_name)
+            metadata_json = slurm.parse_slurm_job_metadata(slurm_id=slurm_id, step_id=step_id)
 
             job_data.memory = metadata_json["max_rss"]
             job_data.runtime = metadata_json["elapsed_seconds"]

--- a/src/slurmise/config.py
+++ b/src/slurmise/config.py
@@ -4,7 +4,7 @@ import tomllib
 from collections import defaultdict
 from pathlib import Path
 
-from slurmise import job_data
+from slurmise import job_data, slurm
 from slurmise.job_parse import file_parsers
 from slurmise.job_parse.job_specification import JobSpec
 
@@ -151,7 +151,7 @@ class SlurmiseConfiguration:
             raise ValueError(msg)
 
         if step_id is not None:
-            slurm_id = ".".join([str(slurm_id), str(step_id)])
+            slurm_id = slurm.resolve_job_id(slurm_id, step_id)
         return job_data.JobData(job_name=job_name, slurm_id=slurm_id, cmd=cmd)
 
     def add_defaults(self, job_data: job_data.JobData) -> job_data.JobData:

--- a/src/slurmise/job_database.py
+++ b/src/slurmise/job_database.py
@@ -173,10 +173,7 @@ class JobDatabase:
         updated_jobs = []
         for job in jobs:
             if job.memory is None or job.runtime is None:
-                if "." in job.slurm_id:
-                    slurm_id, step_id = job.slurm_id.split(".")
-                else:
-                    slurm_id, step_id = job.slurm_id, None
+                slurm_id, step_id = slurm.split_job_id(job.slurm_id)
                 job_info = slurm.parse_slurm_job_metadata(slurm_id=slurm_id, step_id=step_id)
 
                 # job dataclass is immutable, so this creates a new object with the updated values

--- a/src/slurmise/slurm.py
+++ b/src/slurmise/slurm.py
@@ -5,19 +5,63 @@ import os
 import subprocess
 from math import ceil
 
+JOB_ID_ENV_VARS = ("SLURM_JOB_ID", "SLURM_JOBID")  # modern name first; SLURM sets both
 
-def parse_slurm_job_metadata(slurm_id: str | None = None, step_name: str | None = None) -> dict:
+
+def get_current_job_id() -> str | None:
+    """Return the job ID of the current SLURM job, or None when not inside a SLURM job."""
+    for env_var in JOB_ID_ENV_VARS:
+        if env_var in os.environ:
+            return os.environ[env_var]
+    return None
+
+
+def resolve_job_id(slurm_id: str | int | None = None, step_id: str | None = None) -> str:
+    """
+    Resolve a job ID, falling back to the current SLURM job's environment.
+    Parameters:
+        slurm_id (str | int | None): The SLURM job ID. If None, the ID is read from the
+            SLURM_JOB_ID environment variable.
+        step_id (str | None): The SLURM step ID. If provided, it is appended to the job ID
+            as "<slurm_id>.<step_id>".
+    Returns:
+        str: The resolved job ID, with the step ID appended if provided.
+    """
+    if slurm_id is None:
+        slurm_id = get_current_job_id()
+    if slurm_id is None:
+        msg = (
+            "slurm_id was not provided and the SLURM_JOB_ID environment variable "
+            "is not set; not running inside a SLURM job."
+        )
+        raise ValueError(msg)
+    slurm_id = str(slurm_id)
+    if step_id is not None and "." not in slurm_id:
+        slurm_id = f"{slurm_id}.{step_id}"
+    return slurm_id
+
+
+def split_job_id(slurm_id: str) -> tuple[str, str | None]:
+    """Split a combined "<slurm_id>.<step_id>" string into its parts."""
+    if "." in slurm_id:
+        job_id, step_id = slurm_id.split(".", 1)
+        return job_id, step_id
+    return slurm_id, None
+
+
+def parse_slurm_job_metadata(slurm_id: str | None = None, step_id: str | None = None) -> dict:
     """
     Return a dictionary of metadata for the current SLURM job.
     Parameters:
         slurm_id (str | None): The SLURM job ID. If None, the function will attempt to retrieve
-            the job ID from the SLURM_JOBID environment variable.
+            the job ID from the SLURM_JOB_ID environment variable.
         step_id (str | None): The SLURM step ID. If None, the function defaults to the last step
             of the job. If provided, it specifies which step's metadata to return.
     Returns:
         dict: A dictionary containing metadata for the specified SLURM job and step.
     """
 
+    slurm_id = resolve_job_id(slurm_id)
     sacct_json = get_slurm_job_sacct(slurm_id)
 
     try:
@@ -35,16 +79,16 @@ def parse_slurm_job_metadata(slurm_id: str | None = None, step_name: str | None 
             steps[step["step"]["id"]] = step
             jobstep_ids.append(step["step"]["id"])
 
-        if step_name is None:
-            step_id = jobstep_ids[-1]
-            step_name = step_id.split(".")[-1]
+        if step_id is None:
+            step_key = jobstep_ids[-1]
+            step_id = step_key.split(".")[-1]
         else:
-            step_id = f"{job_id}.{step_name}"
+            step_key = f"{job_id}.{step_id}"
 
         # In addition, the max requested memory is updated as slurm steps are completed.
-        elapsed_seconds = int(steps[step_id]["time"]["elapsed"])
-        task_count = steps[step_id]["tasks"]["count"]
-        for item in steps[step_id]["tres"]["requested"]["max"]:
+        elapsed_seconds = int(steps[step_key]["time"]["elapsed"])
+        task_count = steps[step_key]["tasks"]["count"]
+        for item in steps[step_key]["tres"]["requested"]["max"]:
             if item["type"] == "mem":
                 max_rss = max(max_rss, ceil(item["count"] / (2**20)) * task_count)  # convert to MB
     except Exception as e:
@@ -53,7 +97,7 @@ def parse_slurm_job_metadata(slurm_id: str | None = None, step_name: str | None 
 
     return {
         "slurm_id": job_id,
-        "step_id": step_name,
+        "step_id": step_id,
         "job_name": job_name,
         "state": state,
         "partition": partition,
@@ -66,11 +110,7 @@ def parse_slurm_job_metadata(slurm_id: str | None = None, step_name: str | None 
 
 
 def get_slurm_job_sacct(slurm_id: str) -> dict:
-    """Return the JSON output of the sacct command for the current SLURM job."""
-    if "SLURM_JOBID" not in os.environ:
-        msg = "Not running in a SLURM job"
-        raise ValueError(msg)
-
+    """Return the JSON output of the sacct command for the given SLURM job."""
     try:
         json_encoded_str = subprocess.check_output(["sacct", "-j", slurm_id, "--json"])
     except subprocess.CalledProcessError as e:

--- a/src/slurmise/slurm.py
+++ b/src/slurmise/slurm.py
@@ -65,13 +65,11 @@ def parse_slurm_job_metadata(slurm_id: str | None = None, step_name: str | None 
     }
 
 
-def get_slurm_job_sacct(slurm_id: str | None = None) -> dict:
+def get_slurm_job_sacct(slurm_id: str) -> dict:
     """Return the JSON output of the sacct command for the current SLURM job."""
-    if slurm_id is None:
-        if "SLURM_JOBID" not in os.environ:
-            msg = "Not running in a SLURM job"
-            raise ValueError(msg)
-        slurm_id = os.environ["SLURM_JOBID"]
+    if "SLURM_JOBID" not in os.environ:
+        msg = "Not running in a SLURM job"
+        raise ValueError(msg)
 
     try:
         json_encoded_str = subprocess.check_output(["sacct", "-j", slurm_id, "--json"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def generate_job_metadata(**kwargs):
                 "task_id": "extern",
                 "name": kwargs.get("job_name", "finetune_vicuna_7b"),
                 "state": {"current": ["RUNNING"]},
-                "partition": "pli-c",
+                "partition": "mypartition",
                 "required": {
                     "CPUs": 96,
                     "memory_per_cpu": {"set": False, "infinite": False, "number": 0},
@@ -44,7 +44,6 @@ def generate_job_metadata(**kwargs):
                                         "id": 2,
                                         "count": kwargs.get("mem_count", 24786677760),
                                         "task": 0,
-                                        "node": "tiger-g04c6n7",
                                     }
                                 ]
                             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,77 @@ class TomlReturn(NamedTuple):
     db: str
 
 
+def generate_job_metadata(**kwargs):
+    """Build a sacct-style JSON dict like `sacct -j <id> --json` returns."""
+    job_id = kwargs.get("job_id", 58976578)
+    step_name = kwargs.get("step_name", "extern")
+    return {
+        "jobs": [
+            {
+                "job_id": job_id,
+                "task_id": "extern",
+                "name": kwargs.get("job_name", "finetune_vicuna_7b"),
+                "state": {"current": ["RUNNING"]},
+                "partition": "pli-c",
+                "required": {
+                    "CPUs": 96,
+                    "memory_per_cpu": {"set": False, "infinite": False, "number": 0},
+                    "memory_per_node": {"set": True, "infinite": False, "number": 729088},
+                },
+                "steps": [
+                    {
+                        "time": {"elapsed": kwargs.get("elapsed", 97201)},
+                        "tasks": {"count": kwargs.get("task_count", 3)},
+                        "step": {"id": f"{job_id}.{step_name}", "name": step_name},
+                        "tres": {
+                            "requested": {
+                                "max": [
+                                    {
+                                        "type": "mem",
+                                        "name": "",
+                                        "id": 2,
+                                        "count": kwargs.get("mem_count", 24786677760),
+                                        "task": 0,
+                                        "node": "tiger-g04c6n7",
+                                    }
+                                ]
+                            }
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def sacct_mock(monkeypatch):
+    """Patch slurmise.slurm.get_slurm_job_sacct with generated sacct JSON.
+
+    Returns a factory: calling it with generate_job_metadata kwargs installs the
+    patch and returns the list of slurm_ids get_slurm_job_sacct is called with.
+    """
+
+    def _patch(**kwargs):
+        calls = []
+
+        def mock_get_slurm_job_sacct(slurm_id):
+            calls.append(slurm_id)
+            return generate_job_metadata(**kwargs)
+
+        monkeypatch.setattr("slurmise.slurm.get_slurm_job_sacct", mock_get_slurm_job_sacct)
+        return calls
+
+    return _patch
+
+
+@pytest.fixture
+def no_slurm_env(monkeypatch):
+    """Remove all SLURM job id variables from the environment."""
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.delenv("SLURM_JOBID", raising=False)
+
+
 @pytest.fixture
 def simple_toml(tmp_path):
     d = tmp_path

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from slurmise import job_database
 from slurmise.api import Slurmise
 from slurmise.job_data import JobData
 
@@ -81,42 +82,48 @@ def test_update_all_models(toml_fixture, request):
             pass
 
 
-def test_raw_record_uses_env_slurm_id(simple_toml):
+def test_raw_record_uses_env_slurm_id(simple_toml, monkeypatch, no_slurm_env, sacct_mock):
     """When slurm_id is None, raw_record should fall back to the SLURM_JOB_ID env var."""
-
-    def mock_metadata(*args, **kwargs):
-        return {
-            "slurm_id": kwargs["slurm_id"],
-            "job_name": "nupack",
-            "state": "COMPLETED",
-            "partition": "",
-            "elapsed_seconds": 97201,
-            "CPUs": 1,
-            "memory_per_cpu": 0,
-            "memory_per_node": 0,
-            "max_rss": 232,
-            "step_id": "external",
-        }
+    sacct_calls = sacct_mock()
+    monkeypatch.setenv("SLURM_JOB_ID", "99999")
 
     job = JobData(job_name="nupack", slurm_id=None)
-
-    with mock.patch.dict("os.environ", {"SLURM_JOB_ID": "99999"}):
-        with mock.patch(
-            "slurmise.slurm.parse_slurm_job_metadata",
-            side_effect=mock_metadata,
-        ):
-            slurmise = Slurmise(simple_toml.toml)
-            slurmise.raw_record(job)
+    slurmise = Slurmise(simple_toml.toml)
+    slurmise.raw_record(job)
 
     assert job.slurm_id == "99999"
+    assert sacct_calls == ["99999"]
 
 
-def test_raw_record_raises_when_no_slurm_id(simple_toml):
+def test_raw_record_raises_when_no_slurm_id(simple_toml, no_slurm_env):
     """When slurm_id is None and SLURM_JOB_ID is not set, raise a descriptive ValueError."""
     job = JobData(job_name="nupack", slurm_id=None)
 
-    env_without_slurm = {k: v for k, v in __import__("os").environ.items() if k != "SLURM_JOB_ID"}
-    with mock.patch.dict("os.environ", env_without_slurm, clear=True):
-        slurmise = Slurmise(simple_toml.toml)
-        with pytest.raises(ValueError, match="SLURM_JOB_ID"):
-            slurmise.raw_record(job)
+    slurmise = Slurmise(simple_toml.toml)
+    with pytest.raises(ValueError, match="SLURM_JOB_ID"):
+        slurmise.raw_record(job)
+
+
+def test_record_step_id_without_slurm_id(simple_toml, monkeypatch, no_slurm_env, sacct_mock):
+    """Regression test for issue 79: --step-id without --slurm-id must resolve the
+    job id from the environment instead of producing the literal id "None.<step>"."""
+    sacct_calls = sacct_mock(step_name="0", task_count=1, mem_count=232 * 2**20)
+    monkeypatch.setenv("SLURM_JOB_ID", "1234")
+
+    slurmise = Slurmise(simple_toml.toml)
+    slurmise.record("nupack monomer -T 2 -C simple", step_id="0")
+
+    assert sacct_calls == ["1234"]
+
+    with job_database.JobDatabase.get_database(simple_toml.db) as db:
+        results = db.query(JobData(job_name="nupack", categories={"complexity": "simple"}))
+        assert [job.slurm_id for job in results] == ["1234.0"]
+        assert results[0].memory == 232
+        assert results[0].runtime == 97201
+
+
+def test_record_step_id_without_slurm_id_or_env(simple_toml, no_slurm_env):
+    """With a step_id but neither slurm_id nor environment, fail with a clear error."""
+    slurmise = Slurmise(simple_toml.toml)
+    with pytest.raises(ValueError, match="SLURM_JOB_ID"):
+        slurmise.record("nupack monomer -T 2 -C simple", step_id="0")

--- a/tests/test_job_database.py
+++ b/tests/test_job_database.py
@@ -415,6 +415,8 @@ def test_delete_all_children(small_db):
 
 
 def test_update_missing_mem_elapsed(empty_h5py_file, monkeypatch):
+    # signature must match slurm.parse_slurm_job_metadata; a mismatch here once
+    # masked a TypeError in update_missing_data
     def mock_parse_slurm_job_metadata(slurm_id, step_id):  # noqa: ARG001
         return {
             "max_rss": 101,

--- a/tests/test_job_database.py
+++ b/tests/test_job_database.py
@@ -415,8 +415,6 @@ def test_delete_all_children(small_db):
 
 
 def test_update_missing_mem_elapsed(empty_h5py_file, monkeypatch):
-    # signature must match slurm.parse_slurm_job_metadata; a mismatch here once
-    # masked a TypeError in update_missing_data
     def mock_parse_slurm_job_metadata(slurm_id, step_id):  # noqa: ARG001
         return {
             "max_rss": 101,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,19 +18,8 @@ def test_missing_toml():
     assert "See readme for more information" in result.output
 
 
-def test_record(simple_toml, monkeypatch):
-    mock_metadata = {
-        "slurm_id": "1234",
-        "job_name": "nupack",
-        "state": "COMPLETED",
-        "partition": "",
-        "elapsed_seconds": 97201,
-        "CPUs": 1,
-        "memory_per_cpu": 0,
-        "memory_per_node": 0,
-        "max_rss": 232,
-    }
-    monkeypatch.setattr("slurmise.slurm.parse_slurm_job_metadata", lambda *args, **kwargs: mock_metadata)
+def test_record(simple_toml, sacct_mock):
+    sacct_mock(task_count=1, mem_count=232 * 2**20)  # parses to max_rss=232, elapsed=97201
 
     runner = CliRunner()
     result = runner.invoke(
@@ -68,22 +57,9 @@ def test_record(simple_toml, monkeypatch):
         assert query_result == excepted_results
 
 
-def test_raw_record(simple_toml, monkeypatch):
+def test_raw_record(simple_toml, sacct_mock):
     """Test the raw_record command."""
-
-    mock_metadata = {
-        "slurm_id": "1234",
-        "step_id": "0",
-        "job_name": "nupack",
-        "state": "COMPLETED",
-        "partition": "",
-        "elapsed_seconds": 97201,
-        "CPUs": 1,
-        "memory_per_cpu": 0,
-        "memory_per_node": 0,
-        "max_rss": 232,
-    }
-    monkeypatch.setattr("slurmise.slurm.parse_slurm_job_metadata", lambda *args, **kwargs: mock_metadata)
+    sacct_mock(task_count=1, mem_count=232 * 2**20)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -145,6 +121,51 @@ def test_raw_record(simple_toml, monkeypatch):
     assert split_std[1].split("-")[-1] == " a=1"
     assert split_std[2].split("-")[-1] == " b=2"
     assert split_std[3].split("-")[-1] == " 1234"
+
+
+def test_record_step_id_without_slurm_id(simple_toml, monkeypatch, no_slurm_env, sacct_mock):
+    """Regression test for issue 79: `record --step-id N` without `--slurm-id` inside
+    a SLURM job must resolve the job id from the environment."""
+    sacct_calls = sacct_mock(step_name="0", task_count=1, mem_count=232 * 2**20)
+    monkeypatch.setenv("SLURM_JOB_ID", "4321")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--toml",
+            simple_toml.toml,
+            "record",
+            "--step-id",
+            "0",
+            "nupack monomer -T 2 -C simple",
+        ],
+    )
+    assert result.exit_code == 0
+    assert sacct_calls == ["4321"]
+
+    with job_database.JobDatabase.get_database(simple_toml.db) as db:
+        results = db.query(JobData(job_name="nupack", categories={"complexity": "simple"}))
+        assert [job.slurm_id for job in results] == ["4321.0"]
+
+
+def test_record_step_id_outside_slurm_job(simple_toml, no_slurm_env):
+    """Without --slurm-id and outside a SLURM job, record fails with a clear error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--toml",
+            simple_toml.toml,
+            "record",
+            "--step-id",
+            "0",
+            "nupack monomer -T 2 -C simple",
+        ],
+    )
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ValueError)
+    assert "SLURM_JOB_ID" in str(result.exception)
 
 
 def test_update_predict(nupack_toml):

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -1,54 +1,10 @@
-from slurmise.slurm import parse_slurm_job_metadata
+import pytest
+
+from slurmise import slurm
 
 
-def generate_job_metadata(**kargs):
-    return {
-        "jobs": [
-            {
-                "job_id": kargs.get("job_id", 58976578),
-                "task_id": "extern",
-                "name": "finetune_vicuna_7b",
-                "state": {"current": ["RUNNING"]},
-                "partition": "pli-c",
-                "required": {
-                    "CPUs": 96,
-                    "memory_per_cpu": {"set": False, "infinite": False, "number": 0},
-                    "memory_per_node": {"set": True, "infinite": False, "number": 729088},
-                },
-                "steps": [
-                    {
-                        "time": {"elapsed": kargs.get("elapsed", 97201)},
-                        "tasks": {"count": kargs.get("task_count", 3)},
-                        "step": {"id": f"{kargs.get('job_id', 58976578)}.extern", "name": "extern"},
-                        "tres": {
-                            "requested": {
-                                "max": [
-                                    {
-                                        "type": "mem",
-                                        "name": "",
-                                        "id": 2,
-                                        "count": kargs.get("mem_count", 24786677760),
-                                        "task": 0,
-                                        "node": "tiger-g04c6n7",
-                                    }
-                                ]
-                            }
-                        },
-                    }
-                ],
-            }
-        ]
-    }
-
-
-def test_parse_slurm_job_metadata(monkeypatch):
-    def mock_get_slurm_job_sacct(slurm_id):  # noqa: ARG001
-        return generate_job_metadata()
-
-    monkeypatch.setattr(
-        "slurmise.slurm.get_slurm_job_sacct",
-        mock_get_slurm_job_sacct,
-    )
+def test_parse_slurm_job_metadata(sacct_mock):
+    sacct_mock()
 
     expected_metadata = {
         "CPUs": 96,
@@ -71,18 +27,12 @@ def test_parse_slurm_job_metadata(monkeypatch):
         "step_id": "extern",
     }
 
-    assert parse_slurm_job_metadata("58976578") == expected_metadata
-    assert parse_slurm_job_metadata("58976578", step_name="extern") == expected_metadata
+    assert slurm.parse_slurm_job_metadata("58976578") == expected_metadata
+    assert slurm.parse_slurm_job_metadata("58976578", step_id="extern") == expected_metadata
 
 
-def test_parse_slurm_job_metadata2(monkeypatch):
-    def mock_get_slurm_job_sacct(slurm_id):  # noqa: ARG001
-        return generate_job_metadata(task_count=5)
-
-    monkeypatch.setattr(
-        "slurmise.slurm.get_slurm_job_sacct",
-        mock_get_slurm_job_sacct,
-    )
+def test_parse_slurm_job_metadata2(sacct_mock):
+    sacct_mock(task_count=5)
 
     expected_metadata = {
         "CPUs": 96,
@@ -105,5 +55,75 @@ def test_parse_slurm_job_metadata2(monkeypatch):
         "step_id": "extern",
     }
 
-    assert parse_slurm_job_metadata("58976578") == expected_metadata
-    assert parse_slurm_job_metadata("58976578", step_name="extern") == expected_metadata
+    assert slurm.parse_slurm_job_metadata("58976578") == expected_metadata
+    assert slurm.parse_slurm_job_metadata("58976578", step_id="extern") == expected_metadata
+
+
+def test_parse_slurm_job_metadata_env_fallback(sacct_mock, monkeypatch, no_slurm_env):
+    calls = sacct_mock()
+    monkeypatch.setenv("SLURM_JOB_ID", "58976578")
+
+    metadata = slurm.parse_slurm_job_metadata()
+
+    assert calls == ["58976578"]
+    assert metadata["slurm_id"] == 58976578
+
+
+def test_parse_slurm_job_metadata_no_id_no_env(sacct_mock, no_slurm_env):
+    sacct_mock()
+
+    with pytest.raises(ValueError, match="SLURM_JOB_ID"):
+        slurm.parse_slurm_job_metadata()
+
+
+def test_get_current_job_id(monkeypatch, no_slurm_env):
+    assert slurm.get_current_job_id() is None
+
+    monkeypatch.setenv("SLURM_JOBID", "111")
+    assert slurm.get_current_job_id() == "111"
+
+    # the modern variable name takes precedence
+    monkeypatch.setenv("SLURM_JOB_ID", "222")
+    assert slurm.get_current_job_id() == "222"
+
+
+def test_resolve_job_id_explicit(no_slurm_env):
+    assert slurm.resolve_job_id("1234") == "1234"
+    assert slurm.resolve_job_id(1234) == "1234"
+    assert slurm.resolve_job_id("1234", step_id="0") == "1234.0"
+    assert slurm.resolve_job_id("1234", step_id="extern") == "1234.extern"
+    # an already combined id is not double-appended
+    assert slurm.resolve_job_id("1234.0", step_id="0") == "1234.0"
+
+
+def test_resolve_job_id_env_fallback(monkeypatch, no_slurm_env):
+    monkeypatch.setenv("SLURM_JOB_ID", "1234")
+    assert slurm.resolve_job_id() == "1234"
+    # the core issue-79 regression: step without an explicit job id
+    assert slurm.resolve_job_id(step_id="0") == "1234.0"
+
+
+def test_resolve_job_id_no_id_no_env(no_slurm_env):
+    with pytest.raises(ValueError, match="SLURM_JOB_ID"):
+        slurm.resolve_job_id()
+    with pytest.raises(ValueError, match="SLURM_JOB_ID"):
+        slurm.resolve_job_id(step_id="0")
+
+
+def test_split_job_id():
+    assert slurm.split_job_id("1234") == ("1234", None)
+    assert slurm.split_job_id("1234.0") == ("1234", "0")
+    assert slurm.split_job_id("1234.extern") == ("1234", "extern")
+    # array job ids have no dot and pass through
+    assert slurm.split_job_id("123_4") == ("123_4", None)
+    assert slurm.split_job_id("123_4.0") == ("123_4", "0")
+
+
+def test_get_slurm_job_sacct_outside_slurm_job(monkeypatch, no_slurm_env):
+    """Post-mortem recording with an explicit id works outside of a SLURM job."""
+    monkeypatch.setattr(
+        "slurmise.slurm.subprocess.check_output",
+        lambda cmd: b'{"jobs": []}',  # noqa: ARG005
+    )
+
+    assert slurm.get_slurm_job_sacct("1234") == {"jobs": []}

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -21,7 +21,7 @@ def test_parse_slurm_job_metadata(sacct_mock):
             "number": 729088,
             "set": True,
         },
-        "partition": "pli-c",
+        "partition": "mypartition",
         "slurm_id": 58976578,
         "state": "RUNNING",
         "step_id": "extern",
@@ -49,8 +49,8 @@ def test_parse_slurm_job_metadata2(sacct_mock):
             "number": 729088,
             "set": True,
         },
-        "partition": "pli-c",
         "slurm_id": 58976578,
+        "partition": "mypartition",
         "state": "RUNNING",
         "step_id": "extern",
     }


### PR DESCRIPTION
Closes #79.

## Problem

- `slurmise record --step-id N` without `--slurm-id` built the literal job id `"None.N"` and ran `sacct -j None` (found while writing the sbatch tutorials).
- The #80 fix read `SLURM_JOB_ID` in `api.raw_record`, putting scheduler-specific knowledge in the wrong layer (and inconsistently: `api.py` read `SLURM_JOB_ID` while `slurm.py` checked `SLURM_JOBID`).
- `get_slurm_job_sacct` refused to run outside a SLURM job even with an explicit job id, blocking post-mortem recording from a login node.
- Latent `TypeError` in `JobDatabase.update_missing_data`: it called `parse_slurm_job_metadata(step_id=...)` but the real kwarg was `step_name`. A mock with the drifted signature masked it in tests.

## Changes

- `slurm.py` now owns all SLURM specifics behind three helpers used everywhere else: `get_current_job_id()` (reads `SLURM_JOB_ID`, then legacy `SLURM_JOBID`), `resolve_job_id(slurm_id, step_id)` (env fallback **before** appending the step id), and `split_job_id()`. `api.py` no longer touches `os.environ` at all.
- `parse_slurm_job_metadata`'s `step_name` parameter renamed to `step_id` to match the CLI, config, and job_database (also makes the `update_missing_data` call site valid).
- Dropped the `SLURM_JOBID` env check in `get_slurm_job_sacct`; the env requirement now only applies to the fallback path, so `record --slurm-id <finished-id>` works from a login node.
- CLI `raw-record` keeps `--slurm-id` required (explicit post-mortem path); `record` gets the env fallback.
- `JobData.slurm_id` stays the combined `"id.step"` string — no DB schema change.

A future scheduler (SGE etc.) would implement the same three-function surface; no dispatch layer added until one exists.

## Tests

- api/CLI tests now mock `get_slurm_job_sacct` (the subprocess boundary) via a shared `sacct_mock` conftest fixture instead of `parse_slurm_job_metadata`, so real id resolution and sacct parsing are exercised — this is the mocking level that would have caught the `step_id`/`step_name` drift.
- New regression tests at API and CLI level: `record --step-id 0` with no `--slurm-id` resolves `<env id>.0` (asserts sacct was called with the env id, never `"None"`); outside a SLURM job it fails with a `ValueError` naming `SLURM_JOB_ID`.
- New unit tests for the three helpers (env precedence, no double-append on combined ids, array-id passthrough, int coercion).

`uv run poe test`: 114 passed, 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)