### PR TITLE
Avoid having to provide --step-id to slurmise record

### DIFF
--- a/src/slurmise/job_database.py
+++ b/src/slurmise/job_database.py
@@ -82,17 +82,29 @@ class JobDatabase:
 
         table = self.db.require_group(name=table_name)
 
-        if job_data.memory is not None:
-            val = np.asarray(job_data.memory)
-            _ = table.create_dataset(name="memory", shape=val.shape, data=val)
+        try:
+            if job_data.memory is not None:
+                val = np.asarray(job_data.memory)
+                _ = table.create_dataset(name="memory", shape=val.shape, data=val)
 
-        if job_data.runtime is not None:
-            val = np.asarray(job_data.runtime)
-            _ = table.create_dataset(name="runtime", shape=val.shape, data=val)
+            if job_data.runtime is not None:
+                val = np.asarray(job_data.runtime)
+                _ = table.create_dataset(name="runtime", shape=val.shape, data=val)
 
-        for var, value in job_data.numerics.items():
-            val = np.asarray(value)
-            _ = table.create_dataset(name=var, shape=val.shape, data=val)
+            for var, value in job_data.numerics.items():
+                val = np.asarray(value)
+                _ = table.create_dataset(name=var, shape=val.shape, data=val)
+        except ValueError as e:
+            if "already exists" in str(e):
+                msg = (
+                    f"A job named '{job_data.job_name}' with slurm-id '{job_data.slurm_id}' "
+                    f"and categories {job_data.categories} already exists in the database. "
+                    "Slurm ids must be unique per job name and category combination. "
+                    "Delete the existing record before re-recording, or pass "
+                    "ignore_existing_job=True to skip jobs that already exist."
+                )
+                raise ValueError(msg) from e
+            raise
 
     def job_exists(self, job_data: JobData) -> bool:
         table_name = JobDatabase.get_table_name(job_data)

--- a/src/slurmise/job_database.py
+++ b/src/slurmise/job_database.py
@@ -82,29 +82,26 @@ class JobDatabase:
 
         table = self.db.require_group(name=table_name)
 
-        try:
-            if job_data.memory is not None:
-                val = np.asarray(job_data.memory)
-                _ = table.create_dataset(name="memory", shape=val.shape, data=val)
+        if job_data.memory is not None:
+            if "memory" in table:
+                msg = f"Job '{job_data.job_name}' slurm-id '{job_data.slurm_id}' already exists ('memory')."
+                raise ValueError(msg)
+            val = np.asarray(job_data.memory)
+            _ = table.create_dataset(name="memory", shape=val.shape, data=val)
 
-            if job_data.runtime is not None:
-                val = np.asarray(job_data.runtime)
-                _ = table.create_dataset(name="runtime", shape=val.shape, data=val)
+        if job_data.runtime is not None:
+            if "runtime" in table:
+                msg = f"Job '{job_data.job_name}' slurm-id '{job_data.slurm_id}' already exists ('runtime')."
+                raise ValueError(msg)
+            val = np.asarray(job_data.runtime)
+            _ = table.create_dataset(name="runtime", shape=val.shape, data=val)
 
-            for var, value in job_data.numerics.items():
-                val = np.asarray(value)
-                _ = table.create_dataset(name=var, shape=val.shape, data=val)
-        except ValueError as e:
-            if "already exists" in str(e):
-                msg = (
-                    f"A job named '{job_data.job_name}' with slurm-id '{job_data.slurm_id}' "
-                    f"and categories {job_data.categories} already exists in the database. "
-                    "Slurm ids must be unique per job name and category combination. "
-                    "Delete the existing record before re-recording, or pass "
-                    "ignore_existing_job=True to skip jobs that already exist."
-                )
-                raise ValueError(msg) from e
-            raise
+        for var, value in job_data.numerics.items():
+            if var in table:
+                msg = f"Job '{job_data.job_name}' slurm-id '{job_data.slurm_id}' already exists ('{var}')."
+                raise ValueError(msg)
+            val = np.asarray(value)
+            _ = table.create_dataset(name=var, shape=val.shape, data=val)
 
     def job_exists(self, job_data: JobData) -> bool:
         table_name = JobDatabase.get_table_name(job_data)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,6 +57,66 @@ def test_record(simple_toml, sacct_mock):
         assert query_result == excepted_results
 
 
+def test_record_duplicate_slurm_id_fails(simple_toml, sacct_mock):
+    # Job 1
+    sacct_mock(task_count=1, mem_count=232 * 2**20)  # parses to max_rss=232, elapsed=97201
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--toml",
+            simple_toml.toml,
+            "record",
+            "--slurm-id",
+            "1234",
+            "nupack monomer -T 2 -C simple",
+        ],
+    )
+    assert result.exit_code == 0
+
+    # Job 2
+    sacct_mock(task_count=1, mem_count=132 * 2**20)  # Now max_rss=132
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--toml",
+            simple_toml.toml,
+            "record",
+            "--slurm-id",
+            "1234",
+            "nupack monomer -T 2 -C simple",
+        ],
+    )
+    assert result.exit_code == 1
+    assert isinstance(result.exception, ValueError)
+    assert "already exists" in str(result.exception)  # Error comes from h5py require_group
+
+    # test that the recorded job was the first one and it wasn't overwritten
+    with job_database.JobDatabase.get_database(simple_toml.db) as db:
+        excepted_results = [
+            JobData(
+                job_name="nupack",
+                slurm_id="1234",
+                runtime=97201,
+                memory=232,  # This indicates it's the first job
+                categories={"complexity": "simple"},
+                numerics={"threads": 2},
+                cmd=None,
+            ),
+        ]
+
+        query = JobData(
+            job_name="nupack",
+            categories={"complexity": "simple"},
+        )
+        query_result = db.query(query)
+
+        assert query_result == excepted_results
+
+
 def test_raw_record(simple_toml, sacct_mock):
     """Test the raw_record command."""
     sacct_mock(task_count=1, mem_count=232 * 2**20)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from click.testing import CliRunner
 
 from slurmise import job_database
@@ -115,6 +116,130 @@ def test_record_duplicate_slurm_id_fails(simple_toml, sacct_mock):
         query_result = db.query(query)
 
         assert query_result == excepted_results
+
+
+def test_record_duplicate_slurm_id_with_step_id_fails(simple_toml, sacct_mock):
+    """Recording the same slurm-id + step-id combination twice should fail the same
+    way as a plain duplicate slurm-id, since the resolved slurm_id ("1234.0") is identical."""
+    # Job 1
+    sacct_mock(step_name="0", task_count=1, mem_count=232 * 2**20)  # parses to max_rss=232, elapsed=97201
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--toml",
+            simple_toml.toml,
+            "record",
+            "--slurm-id",
+            "1234",
+            "--step-id",
+            "0",
+            "nupack monomer -T 2 -C simple",
+        ],
+    )
+    assert result.exit_code == 0
+
+    # Job 2: same slurm-id and same step-id
+    sacct_mock(step_name="0", task_count=1, mem_count=132 * 2**20)  # Now max_rss=132
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--toml",
+            simple_toml.toml,
+            "record",
+            "--slurm-id",
+            "1234",
+            "--step-id",
+            "0",
+            "nupack monomer -T 2 -C simple",
+        ],
+    )
+    assert result.exit_code == 1
+    assert isinstance(result.exception, ValueError)
+    assert "already exists" in str(result.exception)
+
+    # test that the recorded job was the first one and it wasn't overwritten
+    with job_database.JobDatabase.get_database(simple_toml.db) as db:
+        excepted_results = [
+            JobData(
+                job_name="nupack",
+                slurm_id="1234.0",
+                runtime=97201,
+                memory=232,  # This indicates it's the first job
+                categories={"complexity": "simple"},
+                numerics={"threads": 2},
+                cmd=None,
+            ),
+        ]
+
+        query = JobData(
+            job_name="nupack",
+            categories={"complexity": "simple"},
+        )
+        query_result = db.query(query)
+
+        assert query_result == excepted_results
+
+
+@pytest.mark.xfail(
+    reason="Behavior not yet decided (see #84): recording a job with slurm_id=1234, step_id=0 "
+    "is recoreded as '1234.0'. If we then try to record a job with the same slurm_id but "
+    "with no --step-id, we're currently recorded a separate job '1234'. This is unlikely to happen often "
+    "but one option would be to try and auto-increment step-id and have the second job be '1234.1'",
+    strict=True,
+)
+def test_record_missing_step_id_after_stepped_job_should_increment_step_id(simple_toml, sacct_mock):
+    # Job 1: recorded with an explicit step-id of 0
+    sacct_mock(step_name="0", task_count=1, mem_count=232 * 2**20)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--toml",
+            simple_toml.toml,
+            "record",
+            "--slurm-id",
+            "1234",
+            "--step-id",
+            "0",
+            "nupack monomer -T 2 -C simple",
+        ],
+    )
+    assert result.exit_code == 0
+
+    # Job 2: same base slurm-id, but no step-id given.
+    # Desired future behavior: this should be recognized as another step of job 1
+    # and auto-assigned slurm_id "1234.1".
+    sacct_mock(task_count=1, mem_count=132 * 2**20)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--toml",
+            simple_toml.toml,
+            "record",
+            "--slurm-id",
+            "1234",
+            "nupack monomer -T 2 -C simple",
+        ],
+    )
+    assert result.exit_code == 0
+
+    with job_database.JobDatabase.get_database(simple_toml.db) as db:
+        query = JobData(
+            job_name="nupack",
+            categories={"complexity": "simple"},
+        )
+        query_result = db.query(query)
+
+        recorded_slurm_ids = sorted(job.slurm_id for job in query_result)
+
+    assert recorded_slurm_ids == ["1234.0", "1234.1"]
 
 
 def test_raw_record(simple_toml, sacct_mock):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -92,7 +92,7 @@ def test_record_duplicate_slurm_id_fails(simple_toml, sacct_mock):
     )
     assert result.exit_code == 1
     assert isinstance(result.exception, ValueError)
-    assert "already exists" in str(result.exception)  # Error comes from h5py require_group
+    assert "already exists" in str(result.exception)
 
     # test that the recorded job was the first one and it wasn't overwritten
     with job_database.JobDatabase.get_database(simple_toml.db) as db:


### PR DESCRIPTION
> **Note:** This PR description was written by an AI agent, but the code changes were made by hand. Also the PR description was edited by a person.

## Summary

- Relates to #84: the tutorial currently requires `--step-id` because recording multiple `srun`s within the same Slurm job (same base slurm-id) fails once a second `record` call reuses that slurm-id.

- **This branch does not remove the `--step-id` requirement** — none of the solutions proposed in #84 (e.g. an auto-incrementing `--stepped` flag) are implemented here. 

- So far have added `test_record_duplicate_slurm_id_fails` to test_main.py, confirming `slurmise record` correctly rejects re-recording a job whose slurm-id already exists and avoids overwriting the prior records

- Replaces the raw, hard-to-parse h5py error with a clear, actionable `ValueError`.

- Failure is a `ValueError` raised by `table.create_dataset()`, because a dataset already exists as a child of that group. 

- `record()` now checks `name in table` for each field (`memory`, `runtime`, each `numerics` entry) before creating its dataset, and raises a descriptive `ValueError` naming the specific field that's already recorded.

- `JobDatabase.record(..., ignore_existing_job=True)` silently skips (returns early) if *any* field already exists for that slurm-id; the default (`ignore_existing_job=False`) now raises a clear error the moment a specific field already exists. There's no "overwrite" option right now — `JobDatabase.update()` is an unimplemented stub

- So bringing it back to the initial motivation, removing `--step-id` means every `srun` within one Slurm job records under the *same* base slurm-id and hits this error. Slurmise doesn't currently auto-increment step-ids